### PR TITLE
Chore reduce api calls

### DIFF
--- a/lib/cacher.rb
+++ b/lib/cacher.rb
@@ -219,11 +219,32 @@ private
 
   def unmarshal_value(val)
     if marshal?
-      Marshal.load(val)
+      safe_marshal_load(val)
     else
       return nil if val == CACHER_NIL
       val
     end
   end
 
+  def safe_marshal_load(val)
+    Marshal.load(val)
+  rescue ArgumentError => e
+    last_try ||= nil
+    if e.message =~ /^undefined class\/module (.+?)$/
+      const_name = $1
+      raise e if last_try == const_name
+      const_name.respond_to?(:constantize) ? const_name.constantize : const_lookup(const_name)
+      last_try = const_name
+      retry
+    else
+      raise e
+    end
+  end
+
+  def const_lookup(const_name)
+    constant = Object
+    const_name.split('::').each do |name|
+      constant = constant.const_defined?(name) ? constant.const_get(name) : constant.const_missing(name)
+    end
+  end
 end

--- a/lib/cacher.rb
+++ b/lib/cacher.rb
@@ -145,7 +145,9 @@ public
   end
 
   def get_multi(keys)
-    cached_results = cache.read_multi(keys.map { |k| prepare_key(k) }).inject({}) do |results, (key, value)|
+    prepared_keys = keys.map { |k| prepare_key(k) }
+    cached = cache.read_multi(*prepared_keys)
+    cached_results = cached.inject({}) do |results, (key, value)|
       results[key] = unmarshal_value(value)
       results
     end

--- a/lib/cacher.rb
+++ b/lib/cacher.rb
@@ -144,6 +144,15 @@ public
     unmarshal_value(cached)
   end
 
+  def get_multi(keys)
+    cached_results = cache.read_multi(keys.map { |k| prepare_key(k) }).inject({}) do |results, (key, value)|
+      results[key] = unmarshal_value(value)
+      results
+    end
+
+    keys.map { |key| cached_results[prepare_key(key)] }
+  end
+
   def set(key, options={}, &blk)
     val = do_block(&blk)
     cache_set(key, marshal_value(val), options)

--- a/lib/cacher/version.rb
+++ b/lib/cacher/version.rb
@@ -1,5 +1,5 @@
 module Cacher
   def self.version
-    '0.2.0'
+    '0.2.1'
   end
 end

--- a/spec/cacher_spec.rb
+++ b/spec/cacher_spec.rb
@@ -121,6 +121,23 @@ describe Cacher do
 
           assert { cacher.get('foo') == 1 }
         end
+
+        it 'attempts to find missing constants' do
+          module Finders
+            class Keepers; end
+
+            def self.const_missing(name)
+              class_eval "class #{name}; end"
+            end
+          end
+
+          cacher.set('keepers') { Finders::Keepers.new }
+          assert { cacher.get('keepers').is_a? Finders::Keepers }
+          Finders.send :remove_const, 'Keepers'
+          assert { cacher.get('keepers').is_a? Finders::Keepers }
+          Object.send :remove_const, 'Finders'
+          assert { rescuing { cacher.get('keepers') }.is_a? NameError }
+        end
       end
     end
 


### PR DESCRIPTION
* Fixing a bug, `cacher.read_multi` expect a set of parameters as input, not an array as was being passed by the `prepared_keys`variable.
* A minor refactor to make te code more readable
